### PR TITLE
Make company-tooltip-selection visible

### DIFF
--- a/xresources-theme.el
+++ b/xresources-theme.el
@@ -165,7 +165,7 @@
 
    ;; company-mode
    `(company-tooltip ((t (:foreground ,foreground :background ,background))))
-   `(company-tooltip-selection ((t (:foreground ,foreground :background ,background))))
+   `(company-tooltip-selection ((t (:foreground ,background :background ,foreground))))
    `(company-tooltip-mouse ((t (:background ,background))))
    `(company-tooltip-common ((t (:foreground ,green))))
    `(company-tooltip-common-selection ((t (:foreground ,green))))


### PR DESCRIPTION
With its current value it's impossible to see any difference between selected and unselected candidates, what, well, contradicts the very idea of visual selection.